### PR TITLE
Add option for controlling where to open output window

### DIFF
--- a/doc/clam.txt
+++ b/doc/clam.txt
@@ -87,6 +87,15 @@ autoreturning).
 
 Default: 1 (autoreturn is on)
 
+------------------------------------------------------------------------------
+3.2 g:clam_winpos                                   *ClamConfiguration_winpos*
+
+This option control where to open output window: >
+
+    let g:clam_autoreturn = 'topleft'
+
+Default: 'vertical botright' (split vertical, open at far right)
+
 ==============================================================================
 4. License                                                       *ClamLicense*
 

--- a/plugin/clam.vim
+++ b/plugin/clam.vim
@@ -18,6 +18,10 @@ if !exists('g:clam_autoreturn') "{{{
     let g:clam_autoreturn = 1
 endif " }}}
 
+if !exists('g:clam_winpos') "{{{
+    let g:clam_winpos = 'vertical botright'
+endif "}}}
+
 "}}}
 " Function {{{
 
@@ -30,7 +34,7 @@ function! s:Execlam(command)
 
     " Open the new window (or move to an existing one).
     if winnr < 0
-        silent! execute 'botright vnew ' . fnameescape(command)
+        silent! execute g:clam_winpos . ' new ' . fnameescape(command)
     else
         silent! execute winnr . 'wincmd w'
     endif


### PR DESCRIPTION
I've added `g:clam_winpos` option. This option controls where to open Clam's output window.
