### PR TITLE
Doc Fix

### DIFF
--- a/doc/clam.txt
+++ b/doc/clam.txt
@@ -117,7 +117,7 @@ Default: 1 (autoreturn is on)
 
 This option control where to open output window: >
 
-    let g:clam_autoreturn = 'topleft'
+    let g:clam_winpos = 'topleft'
 
 See the following topics for more information: |:vertical|, |:aboveleft|,
 |:belowright|, |:topleft|, and |:botright|.


### PR DESCRIPTION
You accidentally reused g:clam_autoreturn as the global variable name in the example of configuring the clam_winpos option.
