### PR TITLE
Fix: only run AnsiEsc when creating the Clam window

### DIFF
--- a/plugin/clam.vim
+++ b/plugin/clam.vim
@@ -34,6 +34,11 @@ function! s:GoToClamBuffer(command) " {{{
     " Open the new window (or move to an existing one).
     if winnr < 0
         silent! execute g:clam_winpos . ' new ' . buffer_name
+
+        " Highlight ANSI color codes if the AnsiEsc plugin is present.
+        if exists("g:loaded_AnsiEscPlugin")
+            silent! execute 'AnsiEsc'
+        endif
     else
         silent! execute winnr . 'wincmd w'
     endif
@@ -64,11 +69,6 @@ function! s:ConfigureCurrentClamBuffer(command) " {{{
 
     " Map <localleader>p to "pipe" the buffer into a new command.
     silent! execute 'nnoremap <buffer> <LocalLeader>p ggVG!'
-
-    " Highlight ANSI color codes if the AnsiEsc plugin is present.
-    if exists("g:loaded_AnsiEscPlugin")
-        silent! execute 'AnsiEsc'
-    endif
 endfunction " }}}
 function! s:ReplaceCurrentBuffer(contents) " {{{
     normal! ggdG


### PR DESCRIPTION
The AnsiEsc command toggles escape sequence highlighting, this causes ClamRefresh to disable it.